### PR TITLE
GCB-149 Styling rechttrekken

### DIFF
--- a/bumbo/Controllers/BranchesController.cs
+++ b/bumbo/Controllers/BranchesController.cs
@@ -50,7 +50,7 @@ namespace bumbo.Controllers
                  <td class='py-2 px-4'>{item.BranchId}</td>
                  <td class='py-2 px-4'>{item.Employees.Count} medewerkers</td>
                  <td class='py-2 px-4'>{item.Street + " " + item.HouseNumber}</td>
-                 <td class='py-2 px-4'>
+                 <td class='py-2 px-4 text-right'>
                  <button onclick=""window.location.href='../Branches/ReadBranchView?branchId={item.BranchId}'"">✏️</button> 
                  </td>";
 
@@ -102,12 +102,12 @@ namespace bumbo.Controllers
 
             var headers = new List<string> { "Naam", "Filiaal nummer" };
             var tableBuilder = new TableHtmlBuilderAddBranchManager<Employee>();
-            var htmlTable = tableBuilder.GenerateTable("", headers, employees, "", item =>
+            var htmlTable = tableBuilder.GenerateTable(headers, employees, item =>
             {
             return $@"
                  <td class='py-2 px-4'>{item.FirstName + " " + item.LastName}</td>
                  <td class='py-2 px-4'>{newBranch.BranchId}</td>
-                 <td class='py-2 px-4'><a href='/Branches/AddBranchManager?branchId={newBranch.BranchId}&amp;employeeId={item.Id}' class=""bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-6 float-left rounded-xl"" >Kiezen</a><td>";
+                 <td class='py-2 px-4 flex justify-end'><a href='/Branches/AddBranchManager?branchId={newBranch.BranchId}&amp;employeeId={item.Id}' class=""bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-6 float-left rounded-xl"" >Kiezen</a><td>";
             }, branchId, searchTerm, page);
 
             ViewBag.HtmlTable = htmlTable;
@@ -254,13 +254,9 @@ namespace bumbo.Controllers
     }
 }
 
-
-
-
-
 class TableHtmlBuilderAddBranchManager<TItem>
 {
-    public string GenerateTable(string title, List<string> headers, List<TItem> items, string addPageLink, Func<TItem, string> rowTemplate, int branchId, string searchTerm = null, int currentPage = 1, int pageSize = 10)
+    public string GenerateTable(List<string> headers, List<TItem> items, Func<TItem, string> rowTemplate, int branchId, string searchTerm = null, int currentPage = 1, int pageSize = 10)
     {
         if (!string.IsNullOrWhiteSpace(searchTerm))
         {
@@ -279,14 +275,12 @@ class TableHtmlBuilderAddBranchManager<TItem>
 
         var htmlBuilder = new StringBuilder();
         htmlBuilder.AppendLine("<div class='container mx-auto p-10'>" +
-                               "<div class='flex justify-between items-center mb-4'>" +
-                               "<h2 class='mb-4 text-4xl font-bold leading-none tracking-tight text-gray-900'>" + title + "</h2>" +
+                               "<div class='flex justify-center items-center mb-4'>" +
                                "<form method='get' class='flex items-center space-x-4'>" +
                                "<input type='hidden' name='branchId' value=" + branchId + " />" +
-                               "<input type='text' name='searchTerm' value='" + searchTerm + "' placeholder='Zoek naar " + title.ToLower() + "' class='w-full border border-gray-300 rounded-full py-2 px-6 focus:outline-none focus:ring-2 focus:ring-yellow-400' />" +
+                               "<input type='text' name='searchTerm' value='" + searchTerm + "' placeholder='Zoek naar medewerkers' class='w-full border border-gray-300 rounded-full py-2 px-6 focus:outline-none focus:ring-2 focus:ring-yellow-400' />" +
                                "<button type='submit' class='bg-gray-200 text-gray-700 py-2 px-6 rounded-full hover:bg-gray-300'>Zoeken</button>" +
                                "</form>" +
-                               "<button onclick = \"window.location.href='" + addPageLink + "';\" class='bg-gray-600 hover:bg-gray-500 text-white font-semibold py-2 px-6 rounded-xl '>Nieuwe " + title.ToLower() + " </button>" +
                                "</div>"
                                );
         htmlBuilder.AppendLine("<div class='w-full p-6'>");

--- a/bumbo/Controllers/BranchesController.cs
+++ b/bumbo/Controllers/BranchesController.cs
@@ -158,7 +158,7 @@ namespace bumbo.Controllers
             }
         }
 
-        [HttpPost]
+        [HttpGet]
         public IActionResult DeleteBranch(int branchId)
         {
             SetTempDataForToast("updateBranchToast");

--- a/bumbo/Controllers/EmployeesController.cs
+++ b/bumbo/Controllers/EmployeesController.cs
@@ -27,14 +27,14 @@ namespace bumbo.Controllers
         {
             var headers = new List<string> { "Naam", "Achternaam", "Email", "Telefoonnummer",  };
             var tableBuilder = new TableHtmlBuilder<Employee>();
-            var htmlTable = tableBuilder.GenerateTable("", headers, _employeeRepository.GetAllEmployees(), "/medewerkers/aanmaken", item =>
+            var htmlTable = tableBuilder.GenerateTable("Medewerkers", headers, _employeeRepository.GetAllEmployees(), "/medewerkers/aanmaken", item =>
             {
                 return $@"
                     <td class='py-2 px-4'>{item.FirstName}</td>
                     <td class='py-2 px-4'>{item.LastName}</td>
                     <td class='py-2 px-4'>{item.Email}</td>
                     <td class='py-2 px-4'>{item.PhoneNumber}</td>
-                    <td class='py-2 px-4'>
+                    <td class='py-2 px-4 text-right'>
                     <button onclick = ""window.location.href='/medewerkers/bewerken?medewerkerId={item.Id}'"">✏️</button> 
                     <td>";
             }, searchTerm, page);

--- a/bumbo/Controllers/NormsController.cs
+++ b/bumbo/Controllers/NormsController.cs
@@ -114,6 +114,7 @@ public class NormsController : Controller
         }
         return View(viewModel);
     }
+
     private async Task<AddNormViewModel> GetLastWeek(int branchId)
     {
         int week = LastWeek();

--- a/bumbo/Views/Branches/CreateBranchManagerView.cshtml
+++ b/bumbo/Views/Branches/CreateBranchManagerView.cshtml
@@ -6,8 +6,13 @@
 @model CreateBranchManagerViewModel
 
 <div class="mx-40 mt-12">
-    <div><h1 class="text-4xl"><strong><a asp-area="" asp-controller="Branches"
-                asp-action="ReadBranchView" asp-route-branchId="@Model.BranchId"> < </a>Filiaalmanager toevoegen</strong></h1>
+    <div class="mb-6 flex">
+        <a asp-area="" asp-controller="Branches" asp-action="ReadBranchView" asp-route-branchId="@Model.BranchId" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">Standaard template aanmaken</h1>
     </div>
     <div class="mt-8">
         @Html.Raw(ViewBag.HtmlTable)

--- a/bumbo/Views/Branches/CreateBranchView.cshtml
+++ b/bumbo/Views/Branches/CreateBranchView.cshtml
@@ -3,49 +3,48 @@
 }
 
 @model Branch
-<div class="p-16 container mx-auto max-w-6xl">
+<div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
     <div class="mb-6 flex">
-        <a href="/BranchesView" style="margin-right: 25px">
+        <a href="/filialen" style="margin-right: 25px">
             <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
         </a>
-        <h1 class="mb-6 text-3xl font-semibold">Filiaal toevoegen</h1>
+        <h1 class="text-3xl font-semibold">Filiaal toevoegen</h1>
     </div>
 
     <form asp-action="AddBranch" method="post">
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
+        <div class="mt-6 mb-6 flex">
+            <div class="w-full flex flex-col">
                 <label asp-for="Name">Naam</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="Name" />
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="Name" />
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
         </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            
-            <div class="mr-5 w-60 flex flex-col">
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
                 <label asp-for="Street">Straatnaam</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="Street"
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="Street"
                         pattern="^[^\d]*$" title="Straatnaam mag geen cijfers bevatten." />
                 <span asp-validation-for="Street" class="text-danger"></span>
             </div>
-            <div class="mr-5 w-32 flex flex-col">
+            <div class="w-25 flex flex-col">
                 <label asp-for="HouseNumber">Huisnummer</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="HouseNumber"
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="HouseNumber"
                         pattern="^\d+([a-zA-Z]?)$" title="Voer een geldig huisnummer in zoals 17 of 17b" />
                 <span asp-validation-for="HouseNumber" class="text-danger"></span>
             </div>
         </div>
-        <div class="mt-6 mb-6 ml-6 flex">
+        <div class="mt-6 mb-6 flex">
             <div class="mr-5 w-32 flex flex-col">
                 <label asp-for="PostalCode">Postcode</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="PostalCode"
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="PostalCode"
                         pattern="^\d{4} [A-Za-z]{2}$" title="Het formaat is 1111 AA (Vergeet spatie niet)" />
                 <span asp-validation-for="PostalCode" class="text-danger"></span>
             </div>
-            <div class="mr-5 w-60 flex flex-col">
+            <div class="w-full flex flex-col">
                 <label asp-for="CountryName">Land</label>
-                <select asp-for="CountryName" class="bg-light text-sm-start p-2 rounded border-2 border-solid">
+                <select asp-for="CountryName" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full rounded border leading-tight">
                     <option value='Netherlands'>Nederland</option>
                     <option value='Belgium'>België</option>
                     <option value='Germany'>Duitsland</option>
@@ -54,7 +53,7 @@
 
         </div>
 
-        <div class="ml-72 mt-4">
+        <div class="flex justify-end">
             <default-button button-text="Aanmaken" button-type="primary" on-click=""></default-button>
         </div>
 

--- a/bumbo/Views/Branches/CreateBranchView.cshtml
+++ b/bumbo/Views/Branches/CreateBranchView.cshtml
@@ -3,10 +3,14 @@
 }
 
 @model Branch
-
-<div class="ml-60 mt-12">
-    <div>
-        <h1 class="text-4xl"><strong><a asp-area="" asp-controller="Branches" asp-action="BranchesView"> < </a>Filiaal toevoegen</strong></h1>
+<div class="p-16 container mx-auto max-w-6xl">
+    <div class="mb-6 flex">
+        <a href="/BranchesView" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="mb-6 text-3xl font-semibold">Filiaal toevoegen</h1>
     </div>
 
     <form asp-action="AddBranch" method="post">
@@ -22,13 +26,13 @@
             <div class="mr-5 w-60 flex flex-col">
                 <label asp-for="Street">Straatnaam</label>
                 <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="Street"
-                       pattern="^[^\d]*$" title="Straatnaam mag geen cijfers bevatten." />
+                        pattern="^[^\d]*$" title="Straatnaam mag geen cijfers bevatten." />
                 <span asp-validation-for="Street" class="text-danger"></span>
             </div>
             <div class="mr-5 w-32 flex flex-col">
                 <label asp-for="HouseNumber">Huisnummer</label>
                 <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="HouseNumber"
-                       pattern="^\d+([a-zA-Z]?)$" title="Voer een geldig huisnummer in zoals 17 of 17b" />
+                        pattern="^\d+([a-zA-Z]?)$" title="Voer een geldig huisnummer in zoals 17 of 17b" />
                 <span asp-validation-for="HouseNumber" class="text-danger"></span>
             </div>
         </div>
@@ -36,7 +40,7 @@
             <div class="mr-5 w-32 flex flex-col">
                 <label asp-for="PostalCode">Postcode</label>
                 <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="PostalCode"
-                       pattern="^\d{4} [A-Za-z]{2}$" title="Het formaat is 1111 AA (Vergeet spatie niet)" />
+                        pattern="^\d{4} [A-Za-z]{2}$" title="Het formaat is 1111 AA (Vergeet spatie niet)" />
                 <span asp-validation-for="PostalCode" class="text-danger"></span>
             </div>
             <div class="mr-5 w-60 flex flex-col">
@@ -58,8 +62,8 @@
             if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
             {
                 <toast-message toast-id="@TempData["ToastId"]"
-                               message="@TempData["ToastMessage"]"
-                               message-type="@TempData["ToastType"]">
+                                message="@TempData["ToastMessage"]"
+                                message-type="@TempData["ToastType"]">
                 </toast-message>
                 <script>
                     document.addEventListener('DOMContentLoaded', function () {

--- a/bumbo/Views/Branches/ReadBranchView.cshtml
+++ b/bumbo/Views/Branches/ReadBranchView.cshtml
@@ -7,7 +7,7 @@
 
 <div class="ml-32 mt-16">
     <div class="mb-6 flex">
-        <a href="/standaard-templates" style="margin-right: 25px">
+        <a href="/filialen" style="margin-right: 25px">
             <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
             </svg>

--- a/bumbo/Views/Branches/ReadBranchView.cshtml
+++ b/bumbo/Views/Branches/ReadBranchView.cshtml
@@ -6,8 +6,13 @@
 @model ReadBranchViewModel
 
 <div class="ml-32 mt-16">
-    <div>
-        <h1 class="text-4xl"><strong><a asp-area="" asp-controller="Branches" asp-action="BranchesView"> < </a>@Model.Name</strong></h1>
+    <div class="mb-6 flex">
+        <a href="/standaard-templates" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">@Model.Name</h1>
     </div>
 
     <div class="h-72 mb-4 flex justify-between">

--- a/bumbo/Views/Branches/ReadBranchView.cshtml
+++ b/bumbo/Views/Branches/ReadBranchView.cshtml
@@ -8,7 +8,6 @@
 <div class="ml-32 mt-16">
     <div>
         <h1 class="text-4xl"><strong><a asp-area="" asp-controller="Branches" asp-action="BranchesView"> < </a>@Model.Name</strong></h1>
-        <p class="ml-12">Bumbo > @Model.Name</p>
     </div>
 
     <div class="h-72 mb-4 flex justify-between">

--- a/bumbo/Views/Branches/UpdateBranchView.cshtml
+++ b/bumbo/Views/Branches/UpdateBranchView.cshtml
@@ -14,7 +14,7 @@
         <h1 class="text-3xl font-semibold">Filiaal bewerken</h1>
     </div>
 
-    <form asp-action="UpdateBranch" method="post">
+    <form asp-action="UpdateBranch" method="post" id="update-branch">
 
         <input type="hidden" asp-for="BranchId" />
 
@@ -55,17 +55,16 @@
                 </select>
             </div>
         </div>
-        <div class="ml-72 mt-4">
-            <default-button  button-text="Bewerken" button-type="primary"></default-button>
-        </div>
     </form>
-
     <div class="flex justify-end">
-        <form asp-action="DeleteBranch" asp-controller="Branches" method="post">
-            <input type="hidden" name="branchId" value="@Model.BranchId" />
-            <default-button button-text="Verwijderen" button-type="secondary"></default-button>
-        </form>        
+        <default-button button-text="Verwijderen" button-type="delete" on-click="document.getElementById('delete-branch').classList.remove('hidden')" style="margin-right: 10px"></default-button>
+        <default-button button-text="Bewerken" button-type="primary" onclick="document.getElementById('update-branch').submit();"></default-button>
     </div>
+
+    <custom-modal modal-id="delete-branch" body-text="Weet je zeker dat je dit filiaal wilt verwijderen?">
+        <default-button button-text="Delete" button-type="delete" on-click="window.location.href='/Branches/DeleteBranch?branchId=@Model.BranchId'"></default-button>
+        <default-button button-text="Cancel" button-type="secondary" on-click="document.getElementById('delete-branch').classList.add('hidden')"></default-button>
+    </custom-modal>
 </div>
 
 @{

--- a/bumbo/Views/Branches/UpdateBranchView.cshtml
+++ b/bumbo/Views/Branches/UpdateBranchView.cshtml
@@ -4,47 +4,51 @@
 
 @model Branch
 
-<div class="ml-60 mt-12">
-    <div>
-        <h1 class="text-4xl"><strong><a href="javascript:history.back()">< </a>Filiaal bewerken</strong></h1>
-    </div> 
+<div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
+    <div class="mb-6 flex">
+        <a asp-area="" asp-controller="Branches" asp-action="ReadBranchView" asp-route-branchId="@Model.BranchId" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">Filiaal bewerken</h1>
+    </div>
 
     <form asp-action="UpdateBranch" method="post">
 
         <input type="hidden" asp-for="BranchId" />
 
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
+        <div class="mt-6 mb-6 flex">
+            <div class="w-full flex flex-col">
                 <label asp-for="Name">Naam</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="Name" />
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="Name" />
                 <span asp-validation-for="Name" class="text-danger"></span>
             </div>
         </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            
-            <div class="mr-5 w-60 flex flex-col">
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
                 <label asp-for="Street">Straatnaam</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="Street"
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="Street"
                        pattern="^[^\d]*$" title="Straatnaam mag geen cijfers bevatten." />
                 <span asp-validation-for="Street" class="text-danger"></span>
             </div>
-            <div class="mr-5 w-32 flex flex-col">
+            <div class="w-25 flex flex-col">
                 <label asp-for="HouseNumber">Huisnummer</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="HouseNumber"
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="HouseNumber"
                        pattern="^\d+([a-zA-Z]?)$" title="Voer een geldig huisnummer in zoals 17 of 17b" />
                 <span asp-validation-for="HouseNumber" class="text-danger"></span>
             </div>
         </div>
-        <div class="mt-6 mb-6 ml-6 flex">
+        <div class="mt-6 mb-6 flex">
             <div class="mr-5 w-32 flex flex-col">
                 <label asp-for="PostalCode">Postcode</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" asp-for="PostalCode"
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" asp-for="PostalCode"
                        pattern="^\d{4} [A-Za-z]{2}$" title="Het formaat is 1111 AA (Vergeet spatie niet)" />
                 <span asp-validation-for="PostalCode" class="text-danger"></span>
             </div>
-            <div class="mr-5 w-60 flex flex-col">
+            <div class="w-full flex flex-col">
                 <label asp-for="CountryName">Land</label>
-                <select asp-for="CountryName" class="bg-light text-sm-start p-2 rounded border-2 border-solid">
+                <select asp-for="CountryName" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full rounded border leading-tight">
                     <option value='Netherlands'>Nederland</option>
                     <option value='Belgium'>België</option>
                     <option value='Germany'>Duitsland</option>
@@ -56,7 +60,7 @@
         </div>
     </form>
 
-    <div class="w-32 ml-36 mt-4 bottom-14 relative">
+    <div class="flex justify-end">
         <form asp-action="DeleteBranch" asp-controller="Branches" method="post">
             <input type="hidden" name="branchId" value="@Model.BranchId" />
             <default-button button-text="Verwijderen" button-type="secondary"></default-button>

--- a/bumbo/Views/Employees/Create.cshtml
+++ b/bumbo/Views/Employees/Create.cshtml
@@ -13,7 +13,7 @@
                 <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
         </a>
-        <h1 class="text-3xl font-semibold mb-6">Medewerker aanmaken</h1>
+        <h1 class="text-3xl font-semibold">Medewerker aanmaken</h1>
     </div>
     <!-- Title -->
 

--- a/bumbo/Views/Employees/Create.cshtml
+++ b/bumbo/Views/Employees/Create.cshtml
@@ -3,7 +3,7 @@
 @{
     ViewData["Title"] = "Medewerker aanmaken";
     Layout = "_Layout";
-    ViewData["HideLayoutElements"] = true;
+    // ViewData["HideLayoutElements"] = true;
 }
 
 <div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
@@ -21,13 +21,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="FirstName" class="block text-sm font-medium text-gray-700">Voornaam</label>
-                <input asp-for="FirstName" placeholder="John" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="FirstName" placeholder="John" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="FirstName" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="MiddleName" class="block text-sm font-medium text-gray-700">Tussenvoegsel</label>
-                <input asp-for="MiddleName" placeholder="van" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="MiddleName" placeholder="van" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="MiddleName" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -35,13 +35,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="LastName" class="block text-sm font-medium text-gray-700">Achternaam</label>
-                <input asp-for="LastName" placeholder="Doe" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="LastName" placeholder="Doe" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="LastName" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="BirthDate" class="block text-sm font-medium text-gray-700">Geboorte datum</label>
-                <input asp-for="BirthDate" type="date" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="BirthDate" type="date" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="BirthDate" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -49,13 +49,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="PostalCode" class="block text-sm font-medium text-gray-700">Postcode</label>
-                <input asp-for="PostalCode" placeholder="AB1234" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="PostalCode" placeholder="AB1234" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="PostalCode" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="HouseNumber" class="block text-sm font-medium text-gray-700">Huisnummer</label>
-                <input asp-for="HouseNumber" value="1" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="HouseNumber" value="1" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="HouseNumber" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -63,26 +63,26 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="Email" class="block text-sm font-medium text-gray-700">E-mailadres</label>
-                <input asp-for="Email" type="email" placeholder="johnvandoe@live.nl" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="Email" type="email" placeholder="johnvandoe@live.nl" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="Email" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="PhoneNumber" class="block text-sm font-medium text-gray-700">Telefoonnummer</label>
-                <input asp-for="PhoneNumber" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="PhoneNumber" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="PhoneNumber" class="text-sm text-red-600"></span>
             </div>
         </div>
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="BID" class="block text-sm font-medium text-gray-700"></label>
-                <input asp-for="BID" placeholder="123456789" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="BID" placeholder="123456789" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="BID" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="SelectedFunction" class="block text-sm font-medium text-gray-700">Functie</label>
-                <select asp-for="SelectedFunction" asp-items="Model.Functions" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
+                <select asp-for="SelectedFunction" asp-items="Model.Functions" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight">
                     <option value="">None</option>
                 </select>
                 <span asp-validation-for="SelectedFunction" class="text-sm text-red-600"></span>

--- a/bumbo/Views/Employees/Create.cshtml
+++ b/bumbo/Views/Employees/Create.cshtml
@@ -7,15 +7,15 @@
 }
 
 <div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
-    <div class="absolute top-9 -left-24">
-        <a href="/medewerkers">
+    <div class="mb-6 flex">
+        <a href="/medewerkers" style="margin-right: 25px">
             <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
         </a>
+        <h1 class="text-3xl font-semibold mb-6">Medewerker aanmaken</h1>
     </div>
     <!-- Title -->
-    <h1 class="text-3xl font-semibold mb-6">Medewerker aanmaken</h1>
 
     <form asp-action="Create" method="post" class="space-y-6">
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">

--- a/bumbo/Views/Employees/Index.cshtml
+++ b/bumbo/Views/Employees/Index.cshtml
@@ -2,7 +2,6 @@
     ViewData["Title"] = "Medewerker Overzicht";
 }
 
-<!-- Display the generated table -->
 <div class="mx-4 mt-4">
     <div class="mt-6 flex flex-row">
         @Html.Raw(ViewBag.HtmlTable)

--- a/bumbo/Views/Employees/Update.cshtml
+++ b/bumbo/Views/Employees/Update.cshtml
@@ -23,13 +23,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="FirstName" class="block text-sm font-medium text-gray-700">Voornaam</label>
-                <input asp-for="FirstName" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="FirstName" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="FirstName" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="MiddleName" class="block text-sm font-medium text-gray-700">Tussenvoegsel</label>
-                <input asp-for="MiddleName" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="MiddleName" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="MiddleName" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -37,13 +37,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="LastName" class="block text-sm font-medium text-gray-700">Achternaam</label>
-                <input asp-for="LastName" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="LastName" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="LastName" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="BirthDate" class="block text-sm font-medium text-gray-700">Geboorte datum</label>
-                <input asp-for="BirthDate" type="date" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="BirthDate" type="date" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="BirthDate" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -51,13 +51,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="PostalCode" class="block text-sm font-medium text-gray-700">Postcode</label>
-                <input asp-for="PostalCode" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="PostalCode" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="PostalCode" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="HouseNumber" class="block text-sm font-medium text-gray-700">Huisnummer</label>
-                <input asp-for="HouseNumber" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="HouseNumber" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="HouseNumber" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -65,13 +65,13 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="Email" class="block text-sm font-medium text-gray-700">E-mailadres</label>
-                <input asp-for="Email" type="email" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="Email" type="email" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="Email" class="text-sm text-red-600"></span>
             </div>
 
             <div>
                 <label asp-for="PhoneNumber" class="block text-sm font-medium text-gray-700">Telefoonnummer</label>
-                <input asp-for="PhoneNumber" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="PhoneNumber" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="PhoneNumber" class="text-sm text-red-600"></span>
             </div>
         </div>
@@ -79,14 +79,14 @@
         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div>
                 <label asp-for="BID" class="block text-sm font-medium text-gray-700"></label>
-                <input asp-for="BID" placeholder="123456789" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md" />
+                <input asp-for="BID" placeholder="123456789" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                 <span asp-validation-for="BID" class="text-sm text-red-600"></span>
             </div>
             @if (Model.UserManagerOfBranchId != null && Model.BranchAssignments.Any(b => b.BranchId == Model.UserManagerOfBranchId))
             {
                 <div>
                     <label asp-for="SelectedFunction" class="block text-sm font-medium text-gray-700">Functie</label>
-                    <select asp-for="SelectedFunction" asp-items="Model.Functions" class="mt-1 block w-full shadow-sm sm:text-sm border-gray-300 rounded-md">
+                    <select asp-for="SelectedFunction" asp-items="Model.Functions" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full rounded border leading-tight">
                         <option value="">None</option>
                     </select>
                     <span asp-validation-for="SelectedFunction" class="text-sm text-red-600"></span>

--- a/bumbo/Views/Employees/Update.cshtml
+++ b/bumbo/Views/Employees/Update.cshtml
@@ -3,19 +3,19 @@
 @{
     ViewData["Title"] = "Medewerker bewerken";
     Layout = "_Layout";
-    ViewData["HideLayoutElements"] = true;
+    // ViewData["HideLayoutElements"] = true;
 }
 
 <div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
-    <div class="absolute top-9 -left-24">
-        <a href="/medewerkers">
+    <div class="flex">
+        <a href="/medewerkers" style="margin-right: 25px">
             <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
             </svg>
         </a>
-    </div>
 
-    <h1 class="text-3xl font-semibold mb-6">Medewerker bewerken</h1>
+        <h1 class="text-3xl font-semibold mb-6">Medewerker bewerken</h1>
+    </div>
 
     <form asp-action="Update" method="post" class="space-y-6">
         <input type="hidden" asp-for="Id" />
@@ -107,13 +107,11 @@
         }
 
         <div class="flex justify-end mt-6">
+            <default-button button-text="Medewerker verwijderen" button-type="delete" onclick="document.getElementById('deleteEmployeeModal').classList.remove('hidden')" style="margin-right: 10px"></default-button>
             <default-button button-text="Opslaan" button-type="primary" typeof="submit"></default-button>
         </div>
     </form>
 
-    <button type="button" class="text-sm text-red-500 underline hover:text-red-700 mt-2" style="background: none; border: none; padding: 0; cursor: pointer;" onclick="document.getElementById('deleteEmployeeModal').classList.remove('hidden')">
-        Medewerker verwijderen
-    </button>
 
     <custom-modal modal-id="deleteEmployeeModal" body-text="Weet je zeker dat je deze medewerker wilt verwijderen?">
         <form asp-action="DeleteEmployee" method="post" class="inline">
@@ -154,13 +152,13 @@
                                 }
                             </td>
                             <td class="py-2 px-4">@assignment.StartDate.ToString("dd-MM-yyyy")</td>
-                            <td class="py-2 px-4">
+                            <td class="py-2 px-4 flex justify-end">
                                 @if (Model.UserManagerOfBranchId == assignment.BranchId)
                                 {
-                                    <form asp-action="RemoveBranchAssignment" method="post">
+                                    <form asp-action="RemoveBranchAssignment" method="post" id="RemoveBranchAssignment">
                                         <input type="hidden" name="EmployeeId" value="@Model.Id" />
                                         <input type="hidden" name="BranchId" value="@assignment.BranchId" />
-                                        <button type="submit" class="text-red-500 hover:text-red-700">Verwijderen</button>
+                                        <default-button button-text="Verwijderen" button-type="delete" on-click="document.getElementById('RemoveBranchAssignment').submit();"></default-button>
                                     </form>
                                 }
                             </td>

--- a/bumbo/Views/Employees/Update.cshtml
+++ b/bumbo/Views/Employees/Update.cshtml
@@ -14,7 +14,7 @@
             </svg>
         </a>
 
-        <h1 class="text-3xl font-semibold mb-6">Medewerker bewerken</h1>
+        <h1 class="text-3xl font-semibold">Medewerker bewerken</h1>
     </div>
 
     <form asp-action="Update" method="post" class="space-y-6">

--- a/bumbo/Views/Norms/Create.cshtml
+++ b/bumbo/Views/Norms/Create.cshtml
@@ -8,10 +8,15 @@
 
 <div class="flex justify-content-center p-8">
     <div class="container flex flex-col items-center mx-auto max-w-6xl">
-        <div>
-            <h1 class="text-4xl"><strong><a asp-controller="Norms" asp-action="Index"> < </a>Normering toevoegen</strong></h1>
+        <div class="mb-6 flex">
+            <a href="/normeringen" style="margin-right: 25px">
+                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+            </a>
+            <h1 class="text-3xl font-semibold mb-6">Normering toevoegen</h1>
         </div>
-        <div class="mt-6 mb-6 ml-6 flex">
+        <div class=" mb-6 ml-6 flex">
             <div class="mr-5 w-96 flex flex-col">
                 <default-button button-text="Importeer normering van vorige week" button-type="secondary" on-click="window.location.href='/Norms/Create?lastWeek=true'"></default-button>
             </div>
@@ -74,7 +79,7 @@
                     <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fronting" id="fronting" type="number" name="@nameof(AddNormViewModel.Fronting)" required />
                 </div>
             </div>
-            <div class="d-flex justify-content-end ml-72 mt-4">
+            <div class="flex justify-end mt-6">
                 <default-button button-text="Aanmaken" button-type="primary" on-click=""></default-button>
             </div>
         </form>

--- a/bumbo/Views/Norms/Create.cshtml
+++ b/bumbo/Views/Norms/Create.cshtml
@@ -6,96 +6,94 @@
     var ViewModel = (AddNormViewModel)ViewData["ViewModel"];
 }
 
-<div class="flex justify-content-center p-8">
-    <div class="container flex flex-col items-center mx-auto max-w-6xl">
-        <div class="mb-6 flex">
-            <a href="/normeringen" style="margin-right: 25px">
-                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </a>
-            <h1 class="text-3xl font-semibold mb-6">Normering toevoegen</h1>
-        </div>
-        <div class=" mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <default-button button-text="Importeer normering van vorige week" button-type="secondary" on-click="window.location.href='/Norms/Create?lastWeek=true'"></default-button>
-            </div>
-        </div>
-        <form asp-action="Insert" method="post">
-            <div class="mt-6 ml-6 flex">
-                <div class="mr-2 w-48 flex flex-col">
-                    <label for="year">Kies een jaar</label>
-                    <select class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" id="year" name="@nameof(AddNormViewModel.Year)">
-                        @{
-                            for (int i = DateTime.Now.Year + 1; i > DateTime.Now.Year - 99; i--)
-                            {
-                                if (i == DateTime.Now.Year)
-                                {
-                                    <option selected value="@i">@i</option>
-                                    continue;
-                                }
-                                <option value="@i">@i</option>
-                            }
-                        }
-                    </select>
-                </div>
-                <div class="mr-2 w-48 flex flex-col">
-                    <label for="week">Kies een week</label>
-                    <select class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" id="week" name="@nameof(AddNormViewModel.Week)">
-                        @{
-                            for (int i = 1; i < 53; i++)
-                            {
-                                <option value="@i">Week @i</option>
-                            }
-                        }
-                    </select>
-                </div>
-            </div>
-            <div class="mt-6 ml-6 flex">
-                <div class="mr-2 w-48 flex flex-col">
-                    <label for="unloadColis">Coli uitladen (min)</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.UnloadColis" id="unloadColis" type="number" name="@nameof(AddNormViewModel.UnloadColis)" required />
-                </div>
-                <div class="mr-2 w-48 flex flex-col">
-                    <label for="fillShelves">Vakken vullen (min/coli)</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.FillShelves" id="fillShelves" type="number" name="@nameof(AddNormViewModel.FillShelves)" required />
-                </div>
-            </div>
-            <div class="mt-6 mb-6 ml-6 flex">
-                <div class="mr-5 w-96 flex flex-col">
-                    <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Cashier" id="cashier" type="number" name="@nameof(AddNormViewModel.Cashier)" required />
-                </div>
-            </div>
-            <div class="mt-6 mb-6 ml-6 flex">
-                <div class="mr-5 w-96 flex flex-col">
-                    <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fresh" id="fresh" type="number" name="@nameof(AddNormViewModel.Fresh)" required />
-                </div>
-            </div>
-            <div class="mt-6 mb-6 ml-6 flex">
-                <div class="mr-5 w-96 flex flex-col">
-                    <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fronting" id="fronting" type="number" name="@nameof(AddNormViewModel.Fronting)" required />
-                </div>
-            </div>
-            <div class="flex justify-end mt-6">
-                <default-button button-text="Aanmaken" button-type="primary" on-click=""></default-button>
-            </div>
-        </form>
-        @{
-            if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
-            {
-                <toast-message toast-id="@TempData["ToastId"]"
-                               message="@TempData["ToastMessage"]"
-                               message-type="@TempData["ToastType"]">
-                </toast-message>
-                <script>
-                    document.addEventListener('DOMContentLoaded', function () {
-                        showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
-                    });
-                </script>
-            }
-        }
+<div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
+    <div class="mb-6 flex">
+        <a href="/normeringen" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">Normering toevoegen</h1>
     </div>
+    <div class="mb-6 flex">
+        <div class="mr-5 w-full flex flex-col">
+            <default-button button-text="Importeer normering van vorige week" button-type="secondary" on-click="window.location.href='/Norms/Create?lastWeek=true'"></default-button>
+        </div>
+    </div>
+    <form asp-action="Insert" method="post">
+        <div class="mt-6 flex">
+            <div class="mr-2 w-full flex flex-col">
+                <label for="year">Kies een jaar</label>
+                <select class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full rounded border leading-tight" id="year" name="@nameof(AddNormViewModel.Year)">
+                    @{
+                        for (int i = DateTime.Now.Year + 1; i > DateTime.Now.Year - 99; i--)
+                        {
+                            if (i == DateTime.Now.Year)
+                            {
+                                <option selected value="@i">@i</option>
+                                continue;
+                            }
+                            <option value="@i">@i</option>
+                        }
+                    }
+                </select>
+            </div>
+            <div class="mr-2 w-full flex flex-col">
+                <label for="week">Kies een week</label>
+                <select class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full rounded border leading-tight" id="week" name="@nameof(AddNormViewModel.Week)">
+                    @{
+                        for (int i = 1; i < 53; i++)
+                        {
+                            <option value="@i">Week @i</option>
+                        }
+                    }
+                </select>
+            </div>
+        </div>
+        <div class="mt-6 flex">
+            <div class="mr-2 w-full flex flex-col">
+                <label for="unloadColis">Coli uitladen (min)</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.UnloadColis" id="unloadColis" type="number" name="@nameof(AddNormViewModel.UnloadColis)" required />
+            </div>
+            <div class="mr-2 w-full flex flex-col">
+                <label for="fillShelves">Vakken vullen (min/coli)</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.FillShelves" id="fillShelves" type="number" name="@nameof(AddNormViewModel.FillShelves)" required />
+            </div>
+        </div>
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
+                <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Cashier" id="cashier" type="number" name="@nameof(AddNormViewModel.Cashier)" required />
+            </div>
+        </div>
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
+                <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fresh" id="fresh" type="number" name="@nameof(AddNormViewModel.Fresh)" required />
+            </div>
+        </div>
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
+                <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fronting" id="fronting" type="number" name="@nameof(AddNormViewModel.Fronting)" required />
+            </div>
+        </div>
+        <div class="flex justify-end mt-6">
+            <default-button button-text="Aanmaken" button-type="primary" on-click=""></default-button>
+        </div>
+    </form>
 </div>
+@{
+    if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
+    {
+        <toast-message toast-id="@TempData["ToastId"]"
+                        message="@TempData["ToastMessage"]"
+                        message-type="@TempData["ToastType"]">
+        </toast-message>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
+            });
+        </script>
+    }
+}

--- a/bumbo/Views/Norms/Create.cshtml
+++ b/bumbo/Views/Norms/Create.cshtml
@@ -6,89 +6,91 @@
     var ViewModel = (AddNormViewModel)ViewData["ViewModel"];
 }
 
-<div class="ml-60 mt-12">
-    <div>
-        <h1 class="text-4xl"><strong><a asp-controller="Norms" asp-action="Index"> < </a>Normering toevoegen</strong></h1>
-    </div>
-    <div class="mt-6 mb-6 ml-6 flex">
-        <div class="mr-5 w-96 flex flex-col">
-            <default-button button-text="Importeer normering van vorige week" button-type="secondary" on-click="window.location.href='/Norms/Create?lastWeek=true'"></default-button>
+<div class="flex justify-content-center p-8">
+    <div class="container flex flex-col items-center mx-auto max-w-6xl">
+        <div>
+            <h1 class="text-4xl"><strong><a asp-controller="Norms" asp-action="Index"> < </a>Normering toevoegen</strong></h1>
         </div>
-    </div>
-    <form asp-action="Insert" method="post">
-        <div class="mt-6 ml-6 flex">
-            <div class="mr-2 w-48 flex flex-col">
-                <label for="year">Kies een jaar</label>
-                <select class="bg-light text-sm-start p-2 rounded border-2 border-solid" id="year" name="@nameof(AddNormViewModel.Year)">
-                    @{
-                        for (int i = DateTime.Now.Year + 1; i > DateTime.Now.Year - 99; i--)
-                        {
-                            if (i == DateTime.Now.Year)
+        <div class="mt-6 mb-6 ml-6 flex">
+            <div class="mr-5 w-96 flex flex-col">
+                <default-button button-text="Importeer normering van vorige week" button-type="secondary" on-click="window.location.href='/Norms/Create?lastWeek=true'"></default-button>
+            </div>
+        </div>
+        <form asp-action="Insert" method="post">
+            <div class="mt-6 ml-6 flex">
+                <div class="mr-2 w-48 flex flex-col">
+                    <label for="year">Kies een jaar</label>
+                    <select class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" id="year" name="@nameof(AddNormViewModel.Year)">
+                        @{
+                            for (int i = DateTime.Now.Year + 1; i > DateTime.Now.Year - 99; i--)
                             {
-                                <option selected value="@i">@i</option>
-                                continue;
+                                if (i == DateTime.Now.Year)
+                                {
+                                    <option selected value="@i">@i</option>
+                                    continue;
+                                }
+                                <option value="@i">@i</option>
                             }
-                            <option value="@i">@i</option>
                         }
-                    }
-                </select>
-            </div>
-            <div class="mr-2 w-48 flex flex-col">
-                <label for="week">Kies een week</label>
-                <select class="bg-light text-sm-start p-2 rounded border-2 border-solid" id="week" name="@nameof(AddNormViewModel.Week)">
-                    @{
-                        for (int i = 1; i < 53; i++)
-                        {
-                            <option value="@i">Week @i</option>
+                    </select>
+                </div>
+                <div class="mr-2 w-48 flex flex-col">
+                    <label for="week">Kies een week</label>
+                    <select class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" id="week" name="@nameof(AddNormViewModel.Week)">
+                        @{
+                            for (int i = 1; i < 53; i++)
+                            {
+                                <option value="@i">Week @i</option>
+                            }
                         }
-                    }
-                </select>
+                    </select>
+                </div>
             </div>
-        </div>
-        <div class="mt-6 ml-6 flex">
-            <div class="mr-2 w-48 flex flex-col">
-                <label for="unloadColis">Coli uitladen (min)</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@ViewModel.UnloadColis" id="unloadColis" type="number" name="@nameof(AddNormViewModel.UnloadColis)" required />
+            <div class="mt-6 ml-6 flex">
+                <div class="mr-2 w-48 flex flex-col">
+                    <label for="unloadColis">Coli uitladen (min)</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.UnloadColis" id="unloadColis" type="number" name="@nameof(AddNormViewModel.UnloadColis)" required />
+                </div>
+                <div class="mr-2 w-48 flex flex-col">
+                    <label for="fillShelves">Vakken vullen (min/coli)</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.FillShelves" id="fillShelves" type="number" name="@nameof(AddNormViewModel.FillShelves)" required />
+                </div>
             </div>
-            <div class="mr-2 w-48 flex flex-col">
-                <label for="fillShelves">Vakken vullen (min/coli)</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@ViewModel.FillShelves" id="fillShelves" type="number" name="@nameof(AddNormViewModel.FillShelves)" required />
+            <div class="mt-6 mb-6 ml-6 flex">
+                <div class="mr-5 w-96 flex flex-col">
+                    <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Cashier" id="cashier" type="number" name="@nameof(AddNormViewModel.Cashier)" required />
+                </div>
             </div>
-        </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@ViewModel.Cashier" id="cashier" type="number" name="@nameof(AddNormViewModel.Cashier)" required />
+            <div class="mt-6 mb-6 ml-6 flex">
+                <div class="mr-5 w-96 flex flex-col">
+                    <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fresh" id="fresh" type="number" name="@nameof(AddNormViewModel.Fresh)" required />
+                </div>
             </div>
-        </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@ViewModel.Fresh" id="fresh" type="number" name="@nameof(AddNormViewModel.Fresh)" required />
+            <div class="mt-6 mb-6 ml-6 flex">
+                <div class="mr-5 w-96 flex flex-col">
+                    <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@ViewModel.Fronting" id="fronting" type="number" name="@nameof(AddNormViewModel.Fronting)" required />
+                </div>
             </div>
-        </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@ViewModel.Fronting" id="fronting" type="number" name="@nameof(AddNormViewModel.Fronting)" required />
+            <div class="d-flex justify-content-end ml-72 mt-4">
+                <default-button button-text="Aanmaken" button-type="primary" on-click=""></default-button>
             </div>
-        </div>
-        <div class="d-flex justify-content-end ml-72 mt-4">
-            <default-button button-text="Aanmaken" button-type="primary" on-click=""></default-button>
-        </div>
-    </form>
-    @{
-        if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
-        {
-            <toast-message toast-id="@TempData["ToastId"]"
-                           message="@TempData["ToastMessage"]"
-                           message-type="@TempData["ToastType"]">
-            </toast-message>
-            <script>
-                document.addEventListener('DOMContentLoaded', function () {
-                    showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
-                });
-            </script>
+        </form>
+        @{
+            if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
+            {
+                <toast-message toast-id="@TempData["ToastId"]"
+                               message="@TempData["ToastMessage"]"
+                               message-type="@TempData["ToastType"]">
+                </toast-message>
+                <script>
+                    document.addEventListener('DOMContentLoaded', function () {
+                        showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
+                    });
+                </script>
+            }
         }
-    }
+    </div>
 </div>

--- a/bumbo/Views/Norms/Index.cshtml
+++ b/bumbo/Views/Norms/Index.cshtml
@@ -2,20 +2,23 @@
     ViewData["Title"] = "Normeringen";
 }
 
-<div>
-    @Html.Raw(ViewBag.HtmlTable)
-    @{
-        if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
-        {
-            <toast-message toast-id="@TempData["ToastId"]"
-                           message="@TempData["ToastMessage"]"
-                           message-type="@TempData["ToastType"]">
-            </toast-message>
-            <script>
-                document.addEventListener('DOMContentLoaded', function () {
-                    showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
-                });
-            </script>
-        }
-    }
+<div class="mx-4 mt-4">
+    <div class="mt-6 flex flex-row">
+        @Html.Raw(ViewBag.HtmlTable)
+    </div>
 </div>
+
+@{
+    if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
+    {
+        <toast-message toast-id="@TempData["ToastId"]"
+                        message="@TempData["ToastMessage"]"
+                        message-type="@TempData["ToastType"]">
+        </toast-message>
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
+            });
+        </script>
+    }
+}

--- a/bumbo/Views/Norms/Update.cshtml
+++ b/bumbo/Views/Norms/Update.cshtml
@@ -5,65 +5,63 @@
     ViewData["Title"] = "Normering aanmaken";
 }
 
-<div class="justify-content-center p-8 flex">
-    <div class="container mx-auto flex max-w-6xl flex-col items-center">
-        <div class="mb-6 flex">
-            <a href="/normeringen" style="margin-right: 25px">
-                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </a>
-            <h1 class="mb-6 text-3xl font-semibold">Normering aanpassen</h1>
-        </div>
-        <form asp-action="InsertUpdate" method="post">
-            <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
-            <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
-            <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
-            <div class="mt-6 flex">
-                <div class="mr-2 w-48 flex flex-col">
-                    <label for="unloadColis">Coli uitladen (min)</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
-                </div>
-                <div class="mr-2 w-48 flex flex-col">
-                    <label for="fillShelves">Vakken vullen (min/coli)</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
-                </div>
-            </div>
-            <div class="mt-6 mb-6 flex">
-                <div class="mr-5 w-96 flex flex-col">
-                    <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
-                </div>
-            </div>
-            <div class="mt-6 mb-6 flex">
-                <div class="mr-5 w-96 flex flex-col">
-                    <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
-                </div>
-            </div>
-            <div class="mt-6 mb-6 flex">
-                <div class="mr-5 w-96 flex flex-col">
-                    <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
-                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
-                </div>
-            </div>
-            <div class="mt-6 flex justify-end">
-                <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
-            </div>
-        </form>
-        @{
-            if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
-            {
-                <toast-message toast-id="@TempData["ToastId"]"
-                                message="@TempData["ToastMessage"]"
-                                message-type="@TempData["ToastType"]">
-                </toast-message>
-                <script>
-                    document.addEventListener('DOMContentLoaded', function () {
-                        showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
-                    });
-                </script>
-            }
-        }
+<div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
+    <div class="mb-6 flex">
+        <a href="/normeringen" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">Normering aanpassen</h1>
     </div>
+    <form asp-action="InsertUpdate" method="post">
+        <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
+        <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
+        <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
+        <div class="mt-6 flex">
+            <div class="mr-2 w-full flex flex-col">
+                <label for="unloadColis">Coli uitladen (min)</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
+            </div>
+            <div class="mr-2 w-full flex flex-col">
+                <label for="fillShelves">Vakken vullen (min/coli)</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
+            </div>
+        </div>
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
+                <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
+            </div>
+        </div>
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
+                <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
+            </div>
+        </div>
+        <div class="mt-6 mb-6 flex">
+            <div class="mr-5 w-full flex flex-col">
+                <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
+                <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
+            </div>
+        </div>
+        <div class="mt-6 flex justify-end">
+            <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
+        </div>
+    </form>
+    @{
+        if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
+        {
+            <toast-message toast-id="@TempData["ToastId"]"
+                            message="@TempData["ToastMessage"]"
+                            message-type="@TempData["ToastType"]">
+            </toast-message>
+            <script>
+                document.addEventListener('DOMContentLoaded', function () {
+                    showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
+                });
+            </script>
+        }
+    }
 </div>

--- a/bumbo/Views/Norms/Update.cshtml
+++ b/bumbo/Views/Norms/Update.cshtml
@@ -17,29 +17,29 @@
                 <div class="mt-6 ml-6 flex">
                     <div class="mr-2 w-48 flex flex-col">
                         <label for="unloadColis">Coli uitladen (min)</label>
-                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
+                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
                     </div>
                     <div class="mr-2 w-48 flex flex-col">
                         <label for="fillShelves">Vakken vullen (min/coli)</label>
-                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
+                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
                     </div>
                 </div>
                 <div class="mt-6 mb-6 ml-6 flex">
                     <div class="mr-5 w-96 flex flex-col">
                         <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
-                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
+                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
                     </div>
                 </div>
                 <div class="mt-6 mb-6 ml-6 flex">
                     <div class="mr-5 w-96 flex flex-col">
                         <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
-                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
+                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
                     </div>
                 </div>
                 <div class="mt-6 mb-6 ml-6 flex">
                     <div class="mr-5 w-96 flex flex-col">
                         <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
-                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
+                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
                     </div>
                 </div>
                 <div class="d-flex justify-content-end ml-72 mt-4">

--- a/bumbo/Views/Norms/Update.cshtml
+++ b/bumbo/Views/Norms/Update.cshtml
@@ -7,14 +7,19 @@
 <div class="flex justify-content-center p-8">
     <div class="container flex flex-col items-center mx-auto max-w-6xl">
         <div class="mt-12">
-            <div>
-                <h1 class="text-4xl"><strong><a asp-controller="Norms" asp-action="Index"> < </a>Normering aanpassen</strong></h1>
+            <div class="mb-6 flex">
+                <a href="/normeringen" style="margin-right: 25px">
+                    <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+                    </svg>
+                </a>
+                <h1 class="text-3xl font-semibold mb-6">Normering aanpassen</h1>
             </div>
             <form asp-action="InsertUpdate" method="post">
                 <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
                 <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
                 <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
-                <div class="mt-6 ml-6 flex">
+                <div class="mt-6 flex">
                     <div class="mr-2 w-48 flex flex-col">
                         <label for="unloadColis">Coli uitladen (min)</label>
                         <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
@@ -24,25 +29,25 @@
                         <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
                     </div>
                 </div>
-                <div class="mt-6 mb-6 ml-6 flex">
+                <div class="mt-6 mb-6 flex">
                     <div class="mr-5 w-96 flex flex-col">
                         <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
                         <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
                     </div>
                 </div>
-                <div class="mt-6 mb-6 ml-6 flex">
+                <div class="mt-6 mb-6 flex">
                     <div class="mr-5 w-96 flex flex-col">
                         <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
                         <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
                     </div>
                 </div>
-                <div class="mt-6 mb-6 ml-6 flex">
+                <div class="mt-6 mb-6 flex">
                     <div class="mr-5 w-96 flex flex-col">
                         <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
                         <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
                     </div>
                 </div>
-                <div class="d-flex justify-content-end ml-72 mt-4">
+                <div class="flex justify-end mt-6">
                     <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
                 </div>
             </form>

--- a/bumbo/Views/Norms/Update.cshtml
+++ b/bumbo/Views/Norms/Update.cshtml
@@ -4,59 +4,62 @@
 @{
     ViewData["Title"] = "Normering aanmaken";
 }
-
-<div class="ml-60 mt-12">
-    <div>
-        <h1 class="text-4xl"><strong><a asp-controller="Norms" asp-action="Index"> < </a>Normering aanpassen</strong></h1>
+<div class="flex justify-content-center p-8">
+    <div class="container flex flex-col items-center mx-auto max-w-6xl">
+        <div class="mt-12">
+            <div>
+                <h1 class="text-4xl"><strong><a asp-controller="Norms" asp-action="Index"> < </a>Normering aanpassen</strong></h1>
+            </div>
+            <form asp-action="InsertUpdate" method="post">
+                <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
+                <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
+                <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
+                <div class="mt-6 ml-6 flex">
+                    <div class="mr-2 w-48 flex flex-col">
+                        <label for="unloadColis">Coli uitladen (min)</label>
+                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
+                    </div>
+                    <div class="mr-2 w-48 flex flex-col">
+                        <label for="fillShelves">Vakken vullen (min/coli)</label>
+                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
+                    </div>
+                </div>
+                <div class="mt-6 mb-6 ml-6 flex">
+                    <div class="mr-5 w-96 flex flex-col">
+                        <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
+                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
+                    </div>
+                </div>
+                <div class="mt-6 mb-6 ml-6 flex">
+                    <div class="mr-5 w-96 flex flex-col">
+                        <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
+                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
+                    </div>
+                </div>
+                <div class="mt-6 mb-6 ml-6 flex">
+                    <div class="mr-5 w-96 flex flex-col">
+                        <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
+                        <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
+                    </div>
+                </div>
+                <div class="d-flex justify-content-end ml-72 mt-4">
+                    <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
+                </div>
+            </form>
+            @{
+                if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
+                {
+                    <toast-message toast-id="@TempData["ToastId"]"
+                                   message="@TempData["ToastMessage"]"
+                                   message-type="@TempData["ToastType"]">
+                    </toast-message>
+                    <script>
+                        document.addEventListener('DOMContentLoaded', function () {
+                            showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
+                        });
+                    </script>
+                }
+            }
+        </div>
     </div>
-    <form asp-action="InsertUpdate" method="post">
-        <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
-        <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
-        <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
-        <div class="mt-6 ml-6 flex">
-            <div class="mr-2 w-48 flex flex-col">
-                <label for="unloadColis">Coli uitladen (min)</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
-            </div>
-            <div class="mr-2 w-48 flex flex-col">
-                <label for="fillShelves">Vakken vullen (min/coli)</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
-            </div>
-        </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
-            </div>
-        </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
-            </div>
-        </div>
-        <div class="mt-6 mb-6 ml-6 flex">
-            <div class="mr-5 w-96 flex flex-col">
-                <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
-                <input class="bg-light text-sm-start p-2 rounded border-2 border-solid" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
-            </div>
-        </div>
-        <div class="d-flex justify-content-end ml-72 mt-4">
-            <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
-        </div>
-    </form>
-    @{
-        if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
-        {
-            <toast-message toast-id="@TempData["ToastId"]"
-                           message="@TempData["ToastMessage"]"
-                           message-type="@TempData["ToastType"]">
-            </toast-message>
-            <script>
-                document.addEventListener('DOMContentLoaded', function () {
-                    showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
-                });
-            </script>
-        }
-    }
 </div>

--- a/bumbo/Views/Norms/Update.cshtml
+++ b/bumbo/Views/Norms/Update.cshtml
@@ -4,67 +4,66 @@
 @{
     ViewData["Title"] = "Normering aanmaken";
 }
-<div class="flex justify-content-center p-8">
-    <div class="container flex flex-col items-center mx-auto max-w-6xl">
-        <div class="mt-12">
-            <div class="mb-6 flex">
-                <a href="/normeringen" style="margin-right: 25px">
-                    <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
-                    </svg>
-                </a>
-                <h1 class="text-3xl font-semibold mb-6">Normering aanpassen</h1>
-            </div>
-            <form asp-action="InsertUpdate" method="post">
-                <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
-                <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
-                <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
-                <div class="mt-6 flex">
-                    <div class="mr-2 w-48 flex flex-col">
-                        <label for="unloadColis">Coli uitladen (min)</label>
-                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
-                    </div>
-                    <div class="mr-2 w-48 flex flex-col">
-                        <label for="fillShelves">Vakken vullen (min/coli)</label>
-                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
-                    </div>
-                </div>
-                <div class="mt-6 mb-6 flex">
-                    <div class="mr-5 w-96 flex flex-col">
-                        <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
-                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
-                    </div>
-                </div>
-                <div class="mt-6 mb-6 flex">
-                    <div class="mr-5 w-96 flex flex-col">
-                        <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
-                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
-                    </div>
-                </div>
-                <div class="mt-6 mb-6 flex">
-                    <div class="mr-5 w-96 flex flex-col">
-                        <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
-                        <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
-                    </div>
-                </div>
-                <div class="flex justify-end mt-6">
-                    <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
-                </div>
-            </form>
-            @{
-                if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
-                {
-                    <toast-message toast-id="@TempData["ToastId"]"
-                                   message="@TempData["ToastMessage"]"
-                                   message-type="@TempData["ToastType"]">
-                    </toast-message>
-                    <script>
-                        document.addEventListener('DOMContentLoaded', function () {
-                            showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
-                        });
-                    </script>
-                }
-            }
+
+<div class="justify-content-center p-8 flex">
+    <div class="container mx-auto flex max-w-6xl flex-col items-center">
+        <div class="mb-6 flex">
+            <a href="/normeringen" style="margin-right: 25px">
+                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+            </a>
+            <h1 class="mb-6 text-3xl font-semibold">Normering aanpassen</h1>
         </div>
+        <form asp-action="InsertUpdate" method="post">
+            <input type="hidden" name="@nameof(UpdateNormViewModel.FirstNormId)" value="@Model.FirstNormId" />
+            <input type="hidden" name="@nameof(UpdateNormViewModel.Year)" value="@Model.Year" />
+            <input type="hidden" name="@nameof(UpdateNormViewModel.Week)" value="@Model.Week" />
+            <div class="mt-6 flex">
+                <div class="mr-2 w-48 flex flex-col">
+                    <label for="unloadColis">Coli uitladen (min)</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.UnloadColis" id="unloadColis" type="number" name="@nameof(UpdateNormViewModel.UnloadColis)" required />
+                </div>
+                <div class="mr-2 w-48 flex flex-col">
+                    <label for="fillShelves">Vakken vullen (min/coli)</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.FillShelves" id="fillShelves" type="number" name="@nameof(UpdateNormViewModel.FillShelves)" required />
+                </div>
+            </div>
+            <div class="mt-6 mb-6 flex">
+                <div class="mr-5 w-96 flex flex-col">
+                    <label for="cashier">Hoeveelheid kassiéres per 30 klanten per uur</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Cashier" id="cashier" type="number" name="@nameof(UpdateNormViewModel.Cashier)" required />
+                </div>
+            </div>
+            <div class="mt-6 mb-6 flex">
+                <div class="mr-5 w-96 flex flex-col">
+                    <label for="fresh">Hoeveelheid medewerkers per 100 klanten per uur</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fresh" id="fresh" type="number" name="@nameof(UpdateNormViewModel.Fresh)" required />
+                </div>
+            </div>
+            <div class="mt-6 mb-6 flex">
+                <div class="mr-5 w-96 flex flex-col">
+                    <label for="fronting">Hoeveelheid seconden per meter spiegelen</label>
+                    <input class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" value="@Model.Fronting" id="fronting" type="number" name="@nameof(UpdateNormViewModel.Fronting)" required />
+                </div>
+            </div>
+            <div class="mt-6 flex justify-end">
+                <default-button button-text="Bewerken" button-type="primary" on-click=""></default-button>
+            </div>
+        </form>
+        @{
+            if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
+            {
+                <toast-message toast-id="@TempData["ToastId"]"
+                                message="@TempData["ToastMessage"]"
+                                message-type="@TempData["ToastType"]">
+                </toast-message>
+                <script>
+                    document.addEventListener('DOMContentLoaded', function () {
+                        showToast('@TempData["ToastId"]', '@TempData["AutoHide"]', @TempData["MilSecHide"]);
+                    });
+                </script>
+            }
+        }
     </div>
 </div>

--- a/bumbo/Views/Templates/Create.cshtml
+++ b/bumbo/Views/Templates/Create.cshtml
@@ -4,44 +4,42 @@
     ViewData["Title"] = "Create";
 }
 
-<div class="p-8 container mx-auto max-w-6xl">
-    <div class="p-8">
-        <div class="mb-6 flex">
-            <a href="/standaard-templates" style="margin-right: 25px">
-                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </a>
-            <h1 class="text-3xl font-semibold">Standaard template aanmaken</h1>
-        </div>
-        <div>
-            <form asp-action="Create" method="post" id="createForm">
-                <div class="mb-10">
-                    <label for="Name">Naam:</label><br />
-                    <input asp-for="Name" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" /><br />
+<div class="p-16 container mx-auto max-w-6xl">
+    <div class="mb-6 flex">
+        <a href="/standaard-templates" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">Standaard template aanmaken</h1>
+    </div>
+    <div>
+        <form asp-action="Create" method="post" id="createForm">
+            <div class="mb-10">
+                <label for="Name">Naam:</label><br />
+                <input asp-for="Name" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" /><br />
+            </div>
+            <div class="py-2 border-b">
+                <div class="gap-4 grid grid-cols-3">
+                    <label><b>Dag</b></label>
+                    <label>Aantal verwachte klanten</label>
+                    <label>Aantal verwachte coli</label>
                 </div>
+            </div>
+            @foreach (var day in Model.Days)
+            {
                 <div class="py-2 border-b">
                     <div class="gap-4 grid grid-cols-3">
-                        <label><b>Dag</b></label>
-                        <label>Aantal verwachte klanten</label>
-                        <label>Aantal verwachte coli</label>
+                        <label><b>@day.DayName</b></label>
+                        <input type="number" name="customerData[@day.DayName]" value="@day.CustomerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
+                        <input type="number" name="containerData[@day.DayName]" value="@day.ContainerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                     </div>
                 </div>
-                @foreach (var day in Model.Days)
-                {
-                    <div class="py-2 border-b">
-                        <div class="gap-4 grid grid-cols-3">
-                            <label><b>@day.DayName</b></label>
-                            <input type="number" name="customerData[@day.DayName]" value="@day.CustomerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
-                            <input type="number" name="containerData[@day.DayName]" value="@day.ContainerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
-                        </div>
-                    </div>
-                }
-                <div class="mt-6 flex justify-end">
-                    <default-button button-text="Create" button-type="primary" on-click="document.getEle0mentById('createForm').submit();"></default-button>
-                </div>
-            </form>
-        </div>
+            }
+            <div class="mt-6 flex justify-end">
+                <default-button button-text="Create" button-type="primary" on-click="document.getEle0mentById('createForm').submit();"></default-button>
+            </div>
+        </form>
     </div>
 </div>
 @{

--- a/bumbo/Views/Templates/Create.cshtml
+++ b/bumbo/Views/Templates/Create.cshtml
@@ -4,7 +4,7 @@
     ViewData["Title"] = "Create";
 }
 
-<div class="p-16 container mx-auto max-w-6xl">
+<div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
     <div class="mb-6 flex">
         <a href="/standaard-templates" style="margin-right: 25px">
             <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/bumbo/Views/Templates/Create.cshtml
+++ b/bumbo/Views/Templates/Create.cshtml
@@ -6,8 +6,12 @@
 
 <div class="p-8 container mx-auto max-w-6xl">
     <div class="p-8">
-        <div class="mb-6 flex items-center">
-            <default-button button-text="Terug" button-type="secondary" on-click="window.location.href='../standaard-templates'"></default-button>
+        <div class="mb-6 flex">
+            <a href="/standaard-templates" style="margin-right: 25px">
+                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+            </a>
             <h1 class="text-3xl font-semibold">Standaard template aanmaken</h1>
         </div>
         <div>
@@ -33,7 +37,7 @@
                         </div>
                     </div>
                 }
-                <div class="mt-5">
+                <div class="mt-6 flex justify-end">
                     <default-button button-text="Create" button-type="primary" on-click="document.getEle0mentById('createForm').submit();"></default-button>
                 </div>
             </form>

--- a/bumbo/Views/Templates/Index.cshtml
+++ b/bumbo/Views/Templates/Index.cshtml
@@ -2,9 +2,12 @@
     ViewData["Title"] = "Standaard templates";
 }
 
-<div>
-    @Html.Raw(ViewBag.HtmlTable)
+<div class="mx-4 mt-4">
+    <div class="mt-6 flex flex-row">
+        @Html.Raw(ViewBag.HtmlTable)
+    </div>
 </div>
+
 @{
     if (TempData["ToastMessage"] != null && TempData["ToastType"] != null)
     {

--- a/bumbo/Views/Templates/Update.cshtml
+++ b/bumbo/Views/Templates/Update.cshtml
@@ -10,9 +10,13 @@
             <default-button button-text="Cancel" button-type="secondary" on-click="document.getElementById('delete-template').classList.add('hidden')"></default-button>
         </custom-modal>
 
-        <div class="mb-6 flex items-center">
-            <default-button button-text="Terug" button-type="secondary" on-click="window.location.href='../standaard-templates'"></default-button>
-            <h1 class="text-3xl font-semibold">Standaard template bewerken</h1>
+        <div class="mb-6 flex">
+            <a href="/standaard-templates" style="margin-right: 25px">
+                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+                </svg>
+            </a>
+            <h1 class="text-3xl font-semibold mb-6">Standaard template bewerken</h1>
         </div>
         <div>
             <form asp-action="Update" method="post" id="updateForm">
@@ -39,8 +43,8 @@
                     </div>
                 }
             </form>
-            <div class="mt-5">
-                <default-button button-text="Delete" button-type="delete" on-click="document.getElementById('delete-template').classList.remove('hidden')"></default-button>
+            <div class="mt-6 flex justify-end">
+                <default-button button-text="Delete" button-type="delete" on-click="document.getElementById('delete-template').classList.remove('hidden')" style="margin-right: 10px"></default-button>
                 <default-button button-text="Update" button-type="primary" on-click="document.getElementById('updateForm').submit();"></default-button>
             </div>
         </div>

--- a/bumbo/Views/Templates/Update.cshtml
+++ b/bumbo/Views/Templates/Update.cshtml
@@ -2,51 +2,49 @@
     ViewData["Title"] = "Update";
 }
 
-<div class="p-8 container mx-auto max-w-6xl">
-    <div class="p-8">
+<div class="max-w-2xl mx-auto mt-10 p-6 rounded relative">
 
-        <custom-modal modal-id="delete-template" body-text="Are you sure you want to delete this template?">
-            <default-button button-text="Delete" button-type="delete" on-click="window.location.href='/Templates/Delete?templateId=@ViewBag.Template.TemplateId'"></default-button>
-            <default-button button-text="Cancel" button-type="secondary" on-click="document.getElementById('delete-template').classList.add('hidden')"></default-button>
-        </custom-modal>
+    <custom-modal modal-id="delete-template" body-text="Are you sure you want to delete this template?">
+        <default-button button-text="Delete" button-type="delete" on-click="window.location.href='/Templates/Delete?templateId=@ViewBag.Template.TemplateId'"></default-button>
+        <default-button button-text="Cancel" button-type="secondary" on-click="document.getElementById('delete-template').classList.add('hidden')"></default-button>
+    </custom-modal>
 
-        <div class="mb-6 flex">
-            <a href="/standaard-templates" style="margin-right: 25px">
-                <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
-                </svg>
-            </a>
-            <h1 class="text-3xl font-semibold mb-6">Standaard template bewerken</h1>
-        </div>
-        <div>
-            <form asp-action="Update" method="post" id="updateForm">
-                <input type="hidden" name="templateId" value="@ViewBag.Template.TemplateId" />
-                <div class="mb-10">
-                    <label for="Name">Naam:</label><br />
-                    <input type="text" id="Name" name="Name" value="@ViewBag.Template.Name" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" /><br />
+    <div class="mb-6 flex">
+        <a href="/standaard-templates" style="margin-right: 25px">
+            <svg width="19" height="38" viewBox="0 0 19 38" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M17.2502 35.5L3.66687 21.9167C2.0627 20.3125 2.0627 17.6875 3.66687 16.0833L17.2502 2.5" stroke="black" stroke-width="3.125" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+        </a>
+        <h1 class="text-3xl font-semibold">Standaard template bewerken</h1>
+    </div>
+    <div>
+        <form asp-action="Update" method="post" id="updateForm">
+            <input type="hidden" name="templateId" value="@ViewBag.Template.TemplateId" />
+            <div class="mb-10">
+                <label for="Name">Naam:</label><br />
+                <input type="text" id="Name" name="Name" value="@ViewBag.Template.Name" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" /><br />
+            </div>
+            <div class="py-2 border-b">
+                <div class="gap-4 grid grid-cols-3">
+                    <label><b>Dag</b></label>
+                    <label>Aantal verwachte klanten</label>
+                    <label>Aantal verwachte coli</label>
                 </div>
+            </div>
+            @foreach (TemplateHasDaysViewModel day in ViewBag.Template.HasDays)
+            {
                 <div class="py-2 border-b">
                     <div class="gap-4 grid grid-cols-3">
-                        <label><b>Dag</b></label>
-                        <label>Aantal verwachte klanten</label>
-                        <label>Aantal verwachte coli</label>
+                        <label><b>@day.DayName</b></label>
+                        <input type="number" name="customerData[@day.DayName]" value="@day.CustomerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
+                        <input type="number" name="containerData[@day.DayName]" value="@day.ContainerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
                     </div>
                 </div>
-                @foreach (TemplateHasDaysViewModel day in ViewBag.Template.HasDays)
-                {
-                    <div class="py-2 border-b">
-                        <div class="gap-4 grid grid-cols-3">
-                            <label><b>@day.DayName</b></label>
-                            <input type="number" name="customerData[@day.DayName]" value="@day.CustomerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
-                            <input type="number" name="containerData[@day.DayName]" value="@day.ContainerAmount" class="bg-gray-200 border-gray-400 py-2 px-3 text-gray-700 w-full appearance-none rounded border leading-tight" />
-                        </div>
-                    </div>
-                }
-            </form>
-            <div class="mt-6 flex justify-end">
-                <default-button button-text="Delete" button-type="delete" on-click="document.getElementById('delete-template').classList.remove('hidden')" style="margin-right: 10px"></default-button>
-                <default-button button-text="Update" button-type="primary" on-click="document.getElementById('updateForm').submit();"></default-button>
-            </div>
+            }
+        </form>
+        <div class="mt-6 flex justify-end">
+            <default-button button-text="Delete" button-type="delete" on-click="document.getElementById('delete-template').classList.remove('hidden')" style="margin-right: 10px"></default-button>
+            <default-button button-text="Update" button-type="primary" on-click="document.getElementById('updateForm').submit();"></default-button>
         </div>
     </div>
 </div>


### PR DESCRIPTION
In deze merge is de styling van alle formulieren, knoppen en lijsten gelijkgetrokken zodat iedere pagina dezelfde soort styling heeft.

Dit houdt in dat alle formulieren een grijze achtergrond hebben in de invoervelden, alle verwijder knoppen rood zijn en dat alle knoppen aan de rechter kant staan onder het formulier.

Hierbij betekent dit dat de terugknoppen bij de formulieren en andere pagina's waar dit mogelijk is hetzelfde icoontje zijn geworden dat terugverwijst naar de juiste pagina.

Ook is er een deletemodal toegevoegd aan het bewerken van een filiaal, dit was voorheen nog niet het geval.

Hiernaast zijn bij verschillende lijsten toegevoegd dat de potlood naar de rechterkant is geschoven zodat dit niet op verschillende plaatsen staat in de verticale lijnen bij de verschillende overzichtspagina's onderling. Dit is ook gedaan bij de lijst van het kiezen van een nieuwe medewerker om filiaalmanager te zijn bij een filiaal.

Als laatst is er bij de pagina van het kiezen van een nieuwe filiaalmanager ervoor gezorgd dat de knop "Nieuwe" weg is gehaald inclusief de lege titel. De zoekbalk staat hierbij nog steeds in het midden.